### PR TITLE
Add missing funder entries to Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,11 @@ Package: TENxIO
 Type: Package
 Title: Import methods for 10X Genomics files
 Version: 1.13.3
-Authors@R:
-  person(
-    "Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu",
-    c("aut", "cre"), c(ORCID = "0000-0002-3242-0582")
+Authors@R:c(
+    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-3242-0582")),
+    person("NCI", role = "fnd",
+           comment = c(GrantNo. = "U24CA289073"))
   )
 Depends:
   R (>= 4.5.0),


### PR DESCRIPTION
This automated PR adds missing \`fnd\` (funder) entries to the \`Authors@R\` field in \`DESCRIPTION\` based on the following grant topics set on this repository:

- U24CA289073

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#23510925084](https://github.com/waldronlab/repo-audits/actions/runs/23510925084)).